### PR TITLE
Modernize build: Java 25 + dependency bumps

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,6 +11,6 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '8'
+          java-version: '25'
           cache: maven
       - run: mvn -B -ntp verify

--- a/pom.xml
+++ b/pom.xml
@@ -16,10 +16,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.5.1</version>
+				<version>3.15.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<release>25</release>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -51,32 +50,32 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.0.13</version>
+			<version>1.5.37</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>19.0</version>
+			<version>23.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.airlift</groupId>
 			<artifactId>airline</artifactId>
-			<version>0.7</version>
+			<version>0.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.asynchttpclient</groupId>
 			<artifactId>async-http-client</artifactId>
-			<version>2.0.35</version>
+			<version>3.0.11</version>
 		</dependency>
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
-			<version>2.9.3</version>
+			<version>2.14.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish</groupId>
 			<artifactId>javax.json</artifactId>
-			<version>1.0.4</version>
+			<version>1.1.4</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
## Summary
- Compiler target moved from Java 8 to Java 25 (`maven-compiler-plugin` 3.5.1 → 3.15.0, `<release>25</release>`)
- Dependency versions bumped to the targets already proposed by the open Dependabot PRs:
  - `guava` 19.0 → 23.0
  - `async-http-client` 2.0.35 → 3.0.11
  - `logback-classic` 1.0.13 → 1.5.37
  - `airline` 0.7 → 0.9
  - `joda-time` 2.9.3 → 2.14.2
  - `javax.json` 1.0.4 → 1.1.4

This is a minimal modernization pass — only what Dependabot already flagged, plus the Java 25 toolchain bump. No library replacements or architectural changes.

## Test plan
- [x] `mvn clean compile` on JDK 25
- [x] `mvn test` on JDK 25
- [x] `mvn clean package install` on JDK 25 (shaded jar builds fine)