### PR TITLE
Fix: shade-plugin was stripping the published pom's dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 						<configuration>
 							<shadedArtifactAttached>true</shadedArtifactAttached>
 							<shadedClassifierName>uber</shadedClassifierName>
+							<createDependencyReducedPom>false</createDependencyReducedPom>
 							<transformers>
 								<transformer
 									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">


### PR DESCRIPTION
## Summary
- `maven-shade-plugin`'s `createDependencyReducedPom` defaults to `true`, so every `mvn install`/`mvn deploy` published a pom with an empty `<dependencies>` block instead of the real one.
- Discovered while wiring `hackaton-iot` to consume this artifact as a Maven dependency (added as a git submodule there): `hackaton-iot` failed to compile with `package org.joda.time does not exist` / `package io.netty... does not exist`, because the installed pom no longer declared `joda-time` and `async-http-client` (which pulls in netty) at all.
- Fix: set `<createDependencyReducedPom>false</createDependencyReducedPom>` so the original, full pom gets installed/deployed. The shaded/uber jar (classifier `uber`) is unaffected — it still bundles everything needed to run standalone.

## Test plan
- [x] `mvn clean install` on JDK 25, then inspected the installed pom in `~/.m2` — `joda-time`, `async-http-client`, etc. are present again
- [x] Building `hackaton-iot` against the freshly-installed artifact now resolves `org.joda.time` / `io.netty` transitively as expected